### PR TITLE
Fixes to job application resolver

### DIFF
--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -610,6 +610,11 @@ const resolvers = {
     jobPosting: async (parent) => {
       return await prisma.jobPosting.findUnique({
         where: { jobPostId: parent.jobPostId },
+
+        include: {
+          skillsRequired: true,
+          postedBy: true,
+        },
       })
     },
   },


### PR DESCRIPTION
Now allows skillsRequired to be returned when getting a job posting from a query.